### PR TITLE
feat: add button to change directory

### DIFF
--- a/directory_explorer/index.html
+++ b/directory_explorer/index.html
@@ -98,6 +98,15 @@
             box-shadow: none;
         }
 
+        .btn.folder-btn {
+            background: linear-gradient(135deg, #27ae60, #2ecc71);
+        }
+
+        .btn.folder-btn:hover:not(:disabled) {
+            background: linear-gradient(135deg, #229954, #27ae60);
+            box-shadow: 0 5px 15px rgba(46, 204, 113, 0.4);
+        }
+
         .loading {
             text-align: center;
             padding: 40px;
@@ -180,6 +189,135 @@
             font-size: 1.5rem;
         }
 
+        /* Modal styles */
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0,0,0,0.5);
+            backdrop-filter: blur(5px);
+        }
+
+        .modal-content {
+            background-color: #fefefe;
+            margin: 10% auto;
+            padding: 30px;
+            border-radius: 12px;
+            width: 80%;
+            max-width: 500px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+            animation: modalSlideIn 0.3s ease-out;
+        }
+
+        @keyframes modalSlideIn {
+            from {
+                opacity: 0;
+                transform: translateY(-50px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            padding-bottom: 15px;
+            border-bottom: 2px solid #ecf0f1;
+        }
+
+        .modal-header h2 {
+            margin: 0;
+            color: #2c3e50;
+            font-size: 1.5rem;
+        }
+
+        .close {
+            color: #95a5a6;
+            font-size: 28px;
+            font-weight: bold;
+            cursor: pointer;
+            line-height: 1;
+            transition: color 0.3s ease;
+        }
+
+        .close:hover {
+            color: #e74c3c;
+        }
+
+        .form-group {
+            margin-bottom: 20px;
+        }
+
+        .form-group label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: 500;
+            color: #2c3e50;
+        }
+
+        .form-group input {
+            width: 100%;
+            padding: 12px 15px;
+            border: 2px solid #ecf0f1;
+            border-radius: 6px;
+            font-size: 14px;
+            transition: border-color 0.3s ease;
+        }
+
+        .form-group input:focus {
+            outline: none;
+            border-color: #3498db;
+            box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+        }
+
+        .form-actions {
+            display: flex;
+            gap: 10px;
+            justify-content: flex-end;
+        }
+
+        .btn-secondary {
+            background: linear-gradient(135deg, #95a5a6, #7f8c8d);
+        }
+
+        .btn-secondary:hover {
+            background: linear-gradient(135deg, #7f8c8d, #6c7b7d);
+            box-shadow: 0 5px 15px rgba(149, 165, 166, 0.4);
+        }
+
+        .notification {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            padding: 15px 20px;
+            border-radius: 8px;
+            color: white;
+            font-weight: 500;
+            z-index: 1001;
+            transform: translateX(400px);
+            transition: transform 0.3s ease;
+        }
+
+        .notification.show {
+            transform: translateX(0);
+        }
+
+        .notification.success {
+            background: linear-gradient(135deg, #27ae60, #2ecc71);
+        }
+
+        .notification.error {
+            background: linear-gradient(135deg, #e74c3c, #c0392b);
+        }
+
         @media (max-width: 768px) {
             .container {
                 padding: 20px;
@@ -199,6 +337,12 @@
             .stats {
                 grid-template-columns: 1fr;
             }
+
+            .modal-content {
+                width: 95%;
+                margin: 5% auto;
+                padding: 20px;
+            }
         }
     </style>
 </head>
@@ -217,6 +361,9 @@
         </button>
         <button id="refreshBtn" class="btn" onclick="refresh()">
             🔄 Refresh
+        </button>
+        <button class="btn folder-btn" onclick="openFolderDialog()">
+            📂 Change Folder
         </button>
         <button class="btn" onclick="window.open('/docs', '_blank')">
             📚 API Docs
@@ -251,6 +398,33 @@
 
     <div class="chart-container">
         <canvas id="pieChart"></canvas>
+    </div>
+</div>
+
+<!-- Folder Selection Modal -->
+<div id="folderModal" class="modal">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2>📂 Select Directory</h2>
+            <span class="close" onclick="closeFolderDialog()">&times;</span>
+        </div>
+        <form onsubmit="setNewRoot(event)">
+            <div class="form-group">
+                <label for="folderPath">Directory Path:</label>
+                <input type="text" id="folderPath" placeholder="Enter full directory path (e.g., /home/user/documents)" required>
+                <small style="color: #7f8c8d; margin-top: 5px; display: block;">
+                    Enter the full path to the directory you want to explore
+                </small>
+            </div>
+            <div class="form-actions">
+                <button type="button" class="btn btn-secondary" onclick="closeFolderDialog()">
+                    Cancel
+                </button>
+                <button type="submit" class="btn">
+                    📂 Set Directory
+                </button>
+            </div>
+        </form>
     </div>
 </div>
 
@@ -467,18 +641,123 @@
         }
     }
 
+    // Folder dialog functions
+    function openFolderDialog() {
+        document.getElementById('folderModal').style.display = 'block';
+        document.getElementById('folderPath').focus();
+
+        // Pre-fill with current root path
+        getCurrentRoot().then(root => {
+            document.getElementById('folderPath').value = root;
+        });
+    }
+
+    function closeFolderDialog() {
+        document.getElementById('folderModal').style.display = 'none';
+        document.getElementById('folderPath').value = '';
+    }
+
+    async function getCurrentRoot() {
+        try {
+            const response = await fetch('/api/current-root');
+            const data = await response.json();
+            return data.current_root;
+        } catch (error) {
+            console.error('Error getting current root:', error);
+            return '';
+        }
+    }
+
+    async function setNewRoot(event) {
+        event.preventDefault();
+
+        const newPath = document.getElementById('folderPath').value.trim();
+        if (!newPath) {
+            showNotification('Please enter a directory path', 'error');
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/set-root', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ path: newPath })
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                // Success - close dialog and reload
+                closeFolderDialog();
+                pathHistory = []; // Clear navigation history
+                currentPath = '';
+                showNotification('Directory changed successfully!', 'success');
+                loadDirectory(); // Load the new root directory
+            } else {
+                // Error from server
+                showNotification(result.detail || 'Failed to set directory', 'error');
+            }
+        } catch (error) {
+            console.error('Error setting new root:', error);
+            showNotification('Network error - please try again', 'error');
+        }
+    }
+
+    function showNotification(message, type = 'success') {
+        // Remove existing notifications
+        const existingNotification = document.querySelector('.notification');
+        if (existingNotification) {
+            existingNotification.remove();
+        }
+
+        // Create new notification
+        const notification = document.createElement('div');
+        notification.className = `notification ${type}`;
+        notification.textContent = message;
+        document.body.appendChild(notification);
+
+        // Show notification
+        setTimeout(() => {
+            notification.classList.add('show');
+        }, 100);
+
+        // Hide and remove notification after 3 seconds
+        setTimeout(() => {
+            notification.classList.remove('show');
+            setTimeout(() => {
+                if (notification.parentNode) {
+                    notification.remove();
+                }
+            }, 300);
+        }, 3000);
+    }
+
     // Initialize
     loadDirectory();
 
     // Handle keyboard shortcuts
     document.addEventListener('keydown', function(event) {
-        if (event.key === 'Escape' && pathHistory.length > 0) {
-            goBack();
+        if (event.key === 'Escape') {
+            if (document.getElementById('folderModal').style.display === 'block') {
+                closeFolderDialog();
+            } else if (pathHistory.length > 0) {
+                goBack();
+            }
         } else if (event.key === 'F5' || (event.ctrlKey && event.key === 'r')) {
             event.preventDefault();
             refresh();
         }
     });
+
+    // Close modal when clicking outside
+    window.onclick = function(event) {
+        const modal = document.getElementById('folderModal');
+        if (event.target === modal) {
+            closeFolderDialog();
+        }
+    }
 </script>
 </body>
 </html>

--- a/directory_explorer/index.html
+++ b/directory_explorer/index.html
@@ -752,12 +752,12 @@
     });
 
     // Close modal when clicking outside
-    window.onclick = function(event) {
+    window.addEventListener('click', function(event) {
         const modal = document.getElementById('folderModal');
         if (event.target === modal) {
             closeFolderDialog();
         }
-    }
+    });
 </script>
 </body>
 </html>

--- a/directory_explorer/main.py
+++ b/directory_explorer/main.py
@@ -39,19 +39,42 @@ class SizeFormatResponse(BaseModel):
     size: int
     formatted: str
 
+class SetRootRequest(BaseModel):
+    path: str
+
+class SetRootResponse(BaseModel):
+    success: bool
+    message: str
+    new_root: str
+
 class DirectoryAnalyzer:
     """Analyzes directory structure and calculates sizes with async support"""
-    
+
     def __init__(self, root_path: str):
         self.root_path = Path(root_path).resolve()
         self.cache: Dict[str, int] = {}
         self.executor = ThreadPoolExecutor(max_workers=4)
-    
+
+    def set_root_path(self, new_root: str) -> bool:
+        """Set a new root path and clear cache"""
+        try:
+            new_path = Path(new_root).resolve()
+            if not new_path.exists() or not new_path.is_dir():
+                return False
+
+            self.root_path = new_path
+            self.cache.clear()  # Clear cache when root changes
+            logger.info(f"Root path changed to: {self.root_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Error setting root path: {e}")
+            return False
+
     def _get_directory_size_sync(self, path: Path) -> int:
         """Synchronous directory size calculation for thread pool"""
         if str(path) in self.cache:
             return self.cache[str(path)]
-        
+
         total_size = 0
         try:
             for item in path.rglob('*'):
@@ -64,52 +87,52 @@ class DirectoryAnalyzer:
         except (OSError, PermissionError):
             logger.warning(f"Permission denied for {path}")
             return 0
-        
+
         self.cache[str(path)] = total_size
         return total_size
-    
+
     async def get_directory_size(self, path: Path) -> int:
         """Async directory size calculation"""
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             self.executor, self._get_directory_size_sync, path
         )
-    
+
     async def analyze_directory(self, path: str) -> DirectoryAnalysis:
         """Analyze directory and return size data for visualization"""
         path_obj = Path(path)
         if not path_obj.exists() or not path_obj.is_dir():
             raise HTTPException(
-                status_code=404, 
+                status_code=404,
                 detail="Directory not found or not accessible"
             )
-        
+
         items = []
         total_size = 0
-        
+
         try:
             # Process items concurrently
             tasks = []
             item_paths = []
-            
+
             for item in path_obj.iterdir():
                 if item.name.startswith('.'):
                     continue  # Skip hidden files/directories
-                
+
                 item_paths.append(item)
                 if item.is_dir():
                     tasks.append(self.get_directory_size(item))
                 else:
                     tasks.append(asyncio.create_task(self._get_file_size(item)))
-            
+
             if tasks:
                 sizes = await asyncio.gather(*tasks, return_exceptions=True)
-                
+
                 for item, size in zip(item_paths, sizes):
                     if isinstance(size, Exception):
                         logger.warning(f"Cannot access {item}: {size}")
                         continue
-                    
+
                     item_type = "directory" if item.is_dir() else "file"
                     items.append(DirectoryItem(
                         name=item.name,
@@ -118,24 +141,24 @@ class DirectoryAnalyzer:
                         path=str(item)
                     ))
                     total_size += size
-        
+
         except (OSError, PermissionError) as e:
             raise HTTPException(status_code=403, detail="Permission denied")
-        
+
         # Sort by size (descending)
         items.sort(key=lambda x: x.size, reverse=True)
-        
+
         parent_path = None
         if path_obj != self.root_path:
             parent_path = str(path_obj.parent)
-        
+
         return DirectoryAnalysis(
             path=str(path_obj),
             total_size=total_size,
             items=items,
             parent=parent_path
         )
-    
+
     async def _get_file_size(self, file_path: Path) -> int:
         """Get file size asynchronously"""
         try:
@@ -145,17 +168,17 @@ class DirectoryAnalyzer:
 
 def create_app(root_directory: Optional[str] = None) -> FastAPI:
     """Create FastAPI application"""
-    
+
     if root_directory is None:
         root_directory = os.getcwd()
-    
+
     # Validate root directory
     root_path = Path(root_directory).resolve()
     if not root_path.exists() or not root_path.is_dir():
         raise ValueError(f"Invalid root directory: {root_directory}")
-    
+
     analyzer = DirectoryAnalyzer(str(root_path))
-    
+
     # Create FastAPI app with metadata
     app = FastAPI(
         title="Directory Explorer",
@@ -164,20 +187,20 @@ def create_app(root_directory: Optional[str] = None) -> FastAPI:
         docs_url="/docs",
         redoc_url="/redoc"
     )
-    
+
     # Mount static files if they exist
     static_path = Path(__file__).parent / "static"
     if static_path.exists():
         app.mount("/static", StaticFiles(directory=str(static_path)), name="static")
-    
+
     @app.get("/", response_class=HTMLResponse, tags=["Frontend"])
     async def get_index():
         """Serve the main web interface"""
         return HTMLResponse(content=HTML_TEMPLATE)
-    
+
     @app.get("/api/analyze", response_model=DirectoryAnalysis, tags=["Analysis"])
     async def analyze_directory(
-        path: Optional[str] = Query(None, description="Directory path to analyze")
+            path: Optional[str] = Query(None, description="Directory path to analyze")
     ):
         """
         Analyze directory and return size data for visualization
@@ -186,31 +209,91 @@ def create_app(root_directory: Optional[str] = None) -> FastAPI:
         """
         if path is None:
             path = str(analyzer.root_path)
-        
+
         # Security check: ensure path is within root directory
         try:
             requested_path = Path(path).resolve()
             if not str(requested_path).startswith(str(analyzer.root_path)):
                 raise HTTPException(
-                    status_code=403, 
+                    status_code=403,
                     detail="Access denied - path outside root directory"
                 )
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid path: {str(e)}")
-        
+
         return await analyzer.analyze_directory(path)
-    
+
+    @app.post("/api/set-root", response_model=SetRootResponse, tags=["Navigation"])
+    async def set_root_directory(request: SetRootRequest):
+        """
+        Set a new root directory for exploration
+        
+        - **path**: New root directory path
+        """
+        try:
+            new_path = Path(request.path).resolve()
+
+            # Validate the path exists and is a directory
+            if not new_path.exists():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Directory does not exist: {request.path}"
+                )
+
+            if not new_path.is_dir():
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Path is not a directory: {request.path}"
+                )
+
+            # Check if we have read access
+            try:
+                list(new_path.iterdir())
+            except PermissionError:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Permission denied for directory: {request.path}"
+                )
+
+            # Set the new root
+            success = analyzer.set_root_path(str(new_path))
+
+            if success:
+                return SetRootResponse(
+                    success=True,
+                    message="Root directory updated successfully",
+                    new_root=str(analyzer.root_path)
+                )
+            else:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Failed to set new root directory"
+                )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid path: {str(e)}"
+            )
+
+    @app.get("/api/current-root", tags=["Navigation"])
+    async def get_current_root():
+        """Get the current root directory"""
+        return {"current_root": str(analyzer.root_path)}
+
     @app.get("/api/format_size/{size}", response_model=SizeFormatResponse, tags=["Utilities"])
     async def format_size_endpoint(size: int):
         """Format byte size to human readable format"""
         formatted = format_bytes(size)
         return SizeFormatResponse(size=size, formatted=formatted)
-    
+
     @app.get("/api/health", tags=["Health"])
     async def health_check():
         """Health check endpoint"""
         return {"status": "healthy", "root_directory": str(analyzer.root_path)}
-    
+
     return app
 
 def format_bytes(bytes_size: int) -> str:
@@ -229,40 +312,40 @@ def main():
     """Main entry point"""
     import argparse
     import uvicorn
-    
+
     parser = argparse.ArgumentParser(description='Directory Explorer FastAPI App')
-    parser.add_argument('--directory', '-d', default=os.getcwd(), 
-                       help='Root directory to explore (default: current directory)')
+    parser.add_argument('--directory', '-d', default=os.getcwd(),
+                        help='Root directory to explore (default: current directory)')
     parser.add_argument('--port', '-p', type=int, default=8000,
-                       help='Port to run the web server on (default: 8000)')
+                        help='Port to run the web server on (default: 8000)')
     parser.add_argument('--host', default='127.0.0.1',
-                       help='Host to bind the web server to (default: 127.0.0.1)')
+                        help='Host to bind the web server to (default: 127.0.0.1)')
     parser.add_argument('--reload', action='store_true',
-                       help='Enable auto-reload for development')
+                        help='Enable auto-reload for development')
     parser.add_argument('--workers', type=int, default=1,
-                       help='Number of worker processes')
-    
+                        help='Number of worker processes')
+
     args = parser.parse_args()
-    
+
     # Validate directory
     if not Path(args.directory).exists():
         print(f"❌ Error: Directory '{args.directory}' does not exist")
         return 1
-    
+
     if not Path(args.directory).is_dir():
         print(f"❌ Error: '{args.directory}' is not a directory")
         return 1
-    
+
     print(f"🚀 Starting Directory Explorer (FastAPI)")
     print(f"📁 Root directory: {Path(args.directory).resolve()}")
     print(f"🌐 Web interface: http://{args.host}:{args.port}")
     print(f"📚 API documentation: http://{args.host}:{args.port}/docs")
     print(f"🔍 Click on pie chart slices to navigate into directories")
     print(f"⌨️  Keyboard shortcuts: ESC (back), F5/Ctrl+R (refresh)")
-    
+
     # Create app with specified directory
     app = create_app(args.directory)
-    
+
     # Run with uvicorn
     uvicorn.run(
         app,


### PR DESCRIPTION
Adds support for changing the root directory at runtime by introducing a new API endpoint, backend method, and corresponding UI modal.

- Defines `SetRootRequest`/`SetRootResponse` models and adds `set_root_path` method in `DirectoryAnalyzer`
- Implements `/api/set-root` and `/api/current-root` endpoints
- Adds HTML/CSS/JS for a folder-change modal, button, and notifications in the front end